### PR TITLE
Core patch to fix link_attributes module trowing error when saving field config for `link` field type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -212,7 +212,8 @@
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch",
-                "2245767 - Allow blocks to be configured to show/hide on 403/404 pages": "https://www.drupal.org/files/issues/2021-11-29/2245767-93.patch"
+                "2245767 - Allow blocks to be configured to show/hide on 403/404 pages": "https://www.drupal.org/files/issues/2021-11-29/2245767-93.patch",
+                "2925890 - Invalid config structures can result in exceptions when saving a config entity": "https://www.drupal.org/files/issues/2022-02-08/2925890-37.patch"
             },
             "drupal/media_entity": {
                 "2918172 - Media Entity upgrade -> add revision fields": "https://www.drupal.org/files/issues/2918172-5.patch",


### PR DESCRIPTION
Proposed patch fixes fatal errors that Link Attributes module throws in current setup and allows to update field config for Link field type. 
Applies to Drupal 9.4.x 
