### PR TITLE
Remove patch for 403/404 visibility Rule on Blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -215,7 +215,6 @@
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch",
-                "2245767 - Allow blocks to be configured to show/hide on 403/404 pages": "https://www.drupal.org/files/issues/2023-03-02/2245767-159.patch",
                 "2925890 - Invalid config structures can result in exceptions when saving a config entity": "https://www.drupal.org/files/issues/2022-08-22/2925890-54.patch"
             },
             "drupal/media_entity": {


### PR DESCRIPTION
Remove the patch that is not needed for now. We will use direct rendering of the Webform block on 404 pages via Twig Tweak in corresponding themes.