### PR TITLE
fix: DS-1038 CKE5 breaks out of container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -357,8 +357,8 @@
                 "2925890 - Invalid config structures can result in exceptions when saving a config entity": "https://www.drupal.org/files/issues/2022-08-22/2925890-54.patch",
                 "2922677 - Uncaught TypeError: Cannot read property 'replace' of undefined": "https://www.drupal.org/files/issues/2023-02-15/2922677-33.patch",
                 "3354876 - Media Thumbnail Formatter: alt and title null": "https://git.drupalcode.org/project/drupal/-/merge_requests/4291.diff",
-                "3291764 - The [0] hatch in misc/vertical-tabs.js causes issues if there are multiple forms with vertical tabs.": "https://www.drupal.org/files/issues/2023-04-27/3291764-8.patch"
-
+                "3291764 - The [0] hatch in misc/vertical-tabs.js causes issues if there are multiple forms with vertical tabs.": "https://www.drupal.org/files/issues/2023-04-27/3291764-8.patch",
+                "3145188 - Paragraphs fields cause overflow of content forms in Claro": "https://www.drupal.org/files/issues/2023-01-25/3145188-37_0.patch"
             },
             "drupal/entity_browser": {
                 "2845037 - Fixed the issue of Call to a member function getConfigDependencyKey() on null on [Widget view], and [SelectionDisplay view]": "https://www.drupal.org/files/issues/2845037_15.patch",


### PR DESCRIPTION
https://yusa.atlassian.net/browse/DS-1038

Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 9.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] Edit a node
- [ ] Add a simple content paragraph
- [ ] observe CKE toolbar wraps properly


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
