### PR TITLE
Remove a patch for the Ckeditor Bootstrap Buttons module that 'support' CKeditor 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -387,9 +387,6 @@
             "drupal/ckeditor5_font": {
                 "Issue #3350333: TypeError: array_filter(): Argument #1 ($array) must be of type array.": "https://www.drupal.org/files/issues/2023-04-21/3350333-5.patch"
             },
-            "drupal/ckeditor_bootstrap_buttons": {
-                "Issue #3308035: Drupal 10 & CKEditor 5 Support.": "https://git.drupalcode.org/project/ckeditor_bootstrap_buttons/-/merge_requests/4.patch"
-            },
             "drupal/inline_entity_form": {
                 "Issue #3403113: fixed save sub-block": "https://git.drupalcode.org/project/inline_entity_form/-/merge_requests/94.diff",
                 "Issue #3398615: Save is broken in modal": "https://git.drupalcode.org/project/inline_entity_form/-/merge_requests/95.diff"


### PR DESCRIPTION
For now, this patch is not working as expected.
Moreover, it calls some issues like this one [DS-1322](https://yusa.atlassian.net/browse/DS-1322)
So, it will be better to remove it and find another way to implement this.

## Steps for review

- [ ] go to a site with Lilly or Rose theme (for example, https://sandbox-lily-std-virtual-y.y.org/)
- [ ] verify that the header doesn't break
![image](https://github.com/YCloudYUSA/yusaopeny/assets/744406/09a6e9fd-1275-4709-85aa-761a3b93f7d8)



## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ycloudyusa/yusaopeny/tree/main/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with an account on drupal.org, otherwise, you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
