### PR TITLE
add node.settings.yml like in drupal standart profile

### DIFF
--- a/config/install/node.settings.yml
+++ b/config/install/node.settings.yml
@@ -1,0 +1,1 @@
+use_admin_theme: true


### PR DESCRIPTION
internal ticket https://jet-dev.atlassian.net/browse/ITCR-727

This pull request includes a small change to the `config/install/node.settings.yml` file. The change enables the use of the admin theme.

* [`config/install/node.settings.yml`](diffhunk://#diff-bb95c7dc98668398b98e584baa3d85edd2ae34e34d9a952f9cd504fca99ab57eR1): Set `use_admin_theme` to `true`.
* [solution in core](https://github.com/drupal/core/blob/11.x/profiles/standard/config/install/node.settings.yml)

# How to review
- [ ] Edit some node you should see that claro theme used for render
<img width="1437" alt="Screenshot 2025-02-21 at 12 08 41" src="https://github.com/user-attachments/assets/fe61739a-0464-4dac-acd0-3e701e1d8621" />
