### PR TITLE
Add patch for camp_y fix menu camp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -396,6 +396,9 @@
             },
             "drupal/search_api_solr": {
                 "https://www.drupal.org/project/search_api_solr/issues/3449292#comment-15644442": "https://www.drupal.org/files/issues/2024-06-17/search-api-solr-fatal-error-declaration-of-sleep-3449292-12.patch"
+            },
+            "drupal/y_camp": {
+              "Fix camp manu for subpages": "https://git.drupalcode.org/project/y_camp/-/merge_requests/42.diff"
             }
         }
     },


### PR DESCRIPTION
Original Issue, this PR is going to fix: REPLACE WITH A LINK TO ISSUE ( publicly available )

If you need to post fixed to 10.3 Drupal core - use respective branch https://github.com/YCloudYUSA/yusaopeny/tree/drupal10.3bugfixes

Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use `main` branch. We'll tag for release if the bug is critical ASAP or tag for release next bug fix release until the critical issue arrives.

## Steps for review

- [ ] Please provide steps for review here.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ycloudyusa/yusaopeny/tree/main/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with an account on drupal.org, otherwise, you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
