### PR TITLE
Issue-272: Main menu overlaps logo and User account menu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -400,6 +400,9 @@
             "drupal/core": {
                 "Fix contextual links disappear intermittently leading to console errors https://www.drupal.org/project/drupal/issues/3458067": "https://git.drupalcode.org/project/drupal/-/merge_requests/8585.diff",
                 "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch"
+            },
+            "ycloudyusa/y_lb": {
+                "Fix main menu overlaps logo and User account menu": "https://patch-diff.githubusercontent.com/raw/YCloudYUSA/y_lb/pull/275.diff"
             }
         }
     },


### PR DESCRIPTION
For the test: https://github.com/YCloudYUSA/y_lb/pull/275


Original Issue, this PR is going to fix: REPLACE WITH A LINK TO ISSUE ( publicly available )

Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use `main` branch. We'll tag for release if the bug is critical ASAP or tag for release next bug fix release until the critical issue arrives.

## Steps for review

- [ ] Please provide steps for review here.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ycloudyusa/yusaopeny/tree/main/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with an account on drupal.org, otherwise, you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
