### PR TITLE
[TESTING] fix: Render field_block_item in accordion template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -400,6 +400,9 @@
             "drupal/core": {
                 "Fix contextual links disappear intermittently leading to console errors https://www.drupal.org/project/drupal/issues/3458067": "https://git.drupalcode.org/project/drupal/-/merge_requests/8585.diff",
                 "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch"
+            },
+            "drupal/lb_accordion": {
+                "fix: Render field_block_item in accordion template": "https://git.drupalcode.org/project/lb_accordion/-/merge_requests/27.diff"
             }
         }
     },


### PR DESCRIPTION
Fixed the rendering of the field_block_item field in the accordion block template (lb_accordion).
Previously, the template was using content.field_block_item, which is not always available depending on the view mode configuration. This caused the accordion items to not render properly.
The fix switches to using block_content.field_block_item directly, which ensures reliable access to the referenced entities regardless of view mode settings.

## Steps for review

- [ ] Please create a Landing page and add an accordion block (example FAQ).
- [ ] Make sure that accordion work well.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ycloudyusa/yusaopeny/tree/main/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with an account on drupal.org, otherwise, you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
