### PR TITLE
Issue #3529264: fix menu camp for lb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -400,6 +400,9 @@
             "drupal/core": {
                 "Fix contextual links disappear intermittently leading to console errors https://www.drupal.org/project/drupal/issues/3458067": "https://git.drupalcode.org/project/drupal/-/merge_requests/8585.diff",
                 "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch"
+            },
+            "drupal/y_camp": {
+                "Issue #3529264: fix menu camp for lb": "https://git.drupalcode.org/project/y_camp/-/merge_requests/48.diff"
             }
         }
     },


### PR DESCRIPTION
Issue: https://www.drupal.org/comment/reply/3529264
Testing: https://git.drupalcode.org/project/y_camp/-/merge_requests/48
Original Issue, this PR is going to fix: REPLACE WITH A LINK TO ISSUE ( publicly available )

How to review:

1. Go to https://sandbox-carnation-cus.y.org/camps/camp-colman
2. Enable layout builder and add a camp quick links and main menu
3. View the site on mobile.
4. Make sure that the hamburger menu is not duplicated, the mobile menu does not dark green background.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ycloudyusa/yusaopeny/tree/main/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with an account on drupal.org, otherwise, you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
