### PR TITLE
fix: add patch for migrate_tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -370,6 +370,9 @@
       "drupal/core": {
         "Fix contextual links disappear intermittently leading to console errors https://www.drupal.org/project/drupal/issues/3458067": "https://git.drupalcode.org/project/drupal/-/merge_requests/8585.diff",
         "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch"
+      },
+      "drupal/migrate_tools": {
+        "hook_config_schema_info_alter injected optional migrate_plus config schema https://www.drupal.org/project/migrate_tools/issues/3534606":"https://git.drupalcode.org/project/migrate_tools/-/merge_requests/89.diff"
       }
     }
   },


### PR DESCRIPTION
[skip ci]
hook_config_schema_info_alter injected optional migrate_plus config schema https://www.drupal.org/project/migrate_tools/issues/3534606