### PR TITLE
fix: CSS class is not added to MediaLibrary dialog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -370,7 +370,8 @@
       },
       "drupal/core": {
         "Fix contextual links disappear intermittently leading to console errors https://www.drupal.org/project/drupal/issues/3458067": "https://git.drupalcode.org/project/drupal/-/merge_requests/8585.diff",
-        "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch"
+        "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch",
+        "Class is not added to MediaLibrary dialog": "https://git.drupalcode.org/project/drupal/-/merge_requests/12597.diff"
       },
       "drupal/migrate_tools": {
         "hook_config_schema_info_alter injected optional migrate_plus config schema https://www.drupal.org/project/migrate_tools/issues/3534606":"https://git.drupalcode.org/project/migrate_tools/-/merge_requests/89.diff"

--- a/composer.json
+++ b/composer.json
@@ -371,7 +371,7 @@
       "drupal/core": {
         "Fix contextual links disappear intermittently leading to console errors https://www.drupal.org/project/drupal/issues/3458067": "https://git.drupalcode.org/project/drupal/-/merge_requests/8585.diff",
         "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch",
-        "Class is not added to MediaLibrary dialog": "https://git.drupalcode.org/project/drupal/-/merge_requests/12597.diff"
+        "Class is not added to MediaLibrary dialog https://www.drupal.org/project/drupal/issues/3474018": "https://git.drupalcode.org/project/drupal/-/merge_requests/12597.diff"
       },
       "drupal/migrate_tools": {
         "hook_config_schema_info_alter injected optional migrate_plus config schema https://www.drupal.org/project/migrate_tools/issues/3534606":"https://git.drupalcode.org/project/migrate_tools/-/merge_requests/89.diff"


### PR DESCRIPTION
Issue: https://www.drupal.org/project/drupal/issues/3474018
Patch with fix: https://git.drupalcode.org/project/drupal/-/merge_requests/12597

<img width="1490" height="935" alt="image" src="https://github.com/user-attachments/assets/1afec650-c47d-4a6f-a458-9285cf91d5d5" />



## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ycloudyusa/yusaopeny/tree/main/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with an account on drupal.org, otherwise, you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ycloudyusa/yusaopeny/main/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ycloudyusa/yusaopeny/blob/main/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
