### PR TITLE
feat: add jquery-migrate to core jquery to support jQuery 3.x scripts

### DIFF
--- a/openy.profile
+++ b/openy.profile
@@ -799,3 +799,15 @@ function openy_enable_search_api_solr_legacy() {
   return FALSE;
 }
 
+/**
+ * Implements hook_library_info_alter().
+ */
+function openy_library_info_alter(&$libraries, $extension) {
+  // Add jQuery Migrate 4.x to core/jquery library.
+  if ($extension == 'core' && isset($libraries['jquery'])) {
+    $libraries['jquery']['js']['//code.jquery.com/jquery-migrate-4.0.0-beta.1.js'] = [
+      'type' => 'external',
+      'minified' => TRUE,
+    ];
+  }
+}

--- a/openy.profile
+++ b/openy.profile
@@ -803,7 +803,8 @@ function openy_enable_search_api_solr_legacy() {
  * Implements hook_library_info_alter().
  */
 function openy_library_info_alter(&$libraries, $extension) {
-  // Add jQuery Migrate 4.x to core/jquery library.
+  // Add jQuery Migrate 4.x to core/jquery library. For more info see https://github.com/jquery/jquery-migrate
+  // This fix is needed for scripts that are not compatible with jQuery 4.x yet.
   if ($extension == 'core' && isset($libraries['jquery'])) {
     $libraries['jquery']['js']['//code.jquery.com/jquery-migrate-4.0.0-beta.1.js'] = [
       'type' => 'external',


### PR DESCRIPTION
related:

-  Required changes in carnation theme https://git.drupalcode.org/project/openy_carnation/-/merge_requests/114
- Bootsrtap fork with jQuery fix  https://github.com/YCloudYUSA/bootstrap/tree/4.6.x-migrate-tools

Fix for internal tickets:

- Name has disappeared on the locations D11 - https://jet-dev.atlassian.net/browse/ITCR-811
- Unable to Select Image in Simple Menu Component D11 - https://jet-dev.atlassian.net/browse/ITCR-810
- Pin marker at the locations has disappeared - https://jet-dev.atlassian.net/browse/ITCR-853
- Media list not displayed when selecting "Select media" in the Banner block (Drupal 11 Sandbox) - https://jet-dev.atlassian.net/browse/ITCR-855
- The modal window is not created - https://jet-dev.atlassian.net/browse/ITCR-858
- https://jet-dev.atlassian.net/browse/ITCR-811