### PR TITLE
fix: camp menu block and camp quicks not created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -350,6 +350,7 @@
         "2647312 - Use SubFormState in plugin selectors": "https://www.drupal.org/files/issues/2024-05-14/2647312-38-use-subformstate.patch"
       },
       "drupal/inline_entity_form": {
+        "Issue #2581223: Support for configuration entities": "https://www.drupal.org/files/issues/2025-08-04/rebasepatch_0.patch",
         "Issue #3403113: fixed save sub-block": "https://git.drupalcode.org/project/inline_entity_form/-/merge_requests/94.diff",
         "Issue #3398615: Save is broken in modal": "https://git.drupalcode.org/project/inline_entity_form/-/merge_requests/95.diff"
       },


### PR DESCRIPTION
internal ticket https://jet-dev.atlassian.net/browse/ITCR-856
original issue https://www.drupal.org/project/inline_entity_form/issues/2581223


# How to review

- [ ] As an admin, create or open an existing landing page
- [ ] Create Camp menu block or camp quicks, you should that you can create block and should not see errors in logs
