### PR TITLE
fix: Demo content

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# You should install ansible for ability to run this script
-export PYTHONUNBUFFERED=1
-export ANSIBLE_FORCE_COLOR=true
-time ansible-playbook -vvvv build/tests.yml -i 'localhost,' --connection=local $@


### PR DESCRIPTION
## Problem
Partners block "Our Partners" not displaying partner logos on demo Who We Are page (ITCR-863).
See https://github.com/YCloudYUSA/y_lb_demo_content/pull/58

Migration was referencing partner items directly instead of through tier structure.

## Solution
- Created `y_lb_demo_block_partners_tier` migration
- Updated `y_lb_demo_block_partners` to reference tiers

## Structure
```
lb_partners → field_partners → partners_tier → field_partners_items → lb_partner_item
```

## Testing
```bash
ddev drush mim y_lb_demo_block_partners_item,y_lb_demo_block_partners_tier,y_lb_demo_block_partners,y_lb_demo_page_who_we_are --update
```

Visit `/demo-who-we-are` - partner logos now display correctly.

Fixes: ITCR-863