### PR TITLE
chore: migrate from ycloudyusa/fontyourface to drupal/fontyourface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "drupal/exif_orientation": "^1.5",
     "drupal/field_group": "^3.0",
     "drupal/focal_point": "^2 || ^2.0@alpha",
-    "ycloudyusa/fontyourface": "^4.0.0",
+    "drupal/fontyourface": "^4.1.0",
     "drupal/geolocation": "^3.0",
     "drupal/google_analytics": "^2.5 || ^3.1 || ^4.0 || ^4.0@alpha",
     "drupal/google_tag": "^1.4 || ^2.0",


### PR DESCRIPTION
## Summary
- Replace forked `ycloudyusa/fontyourface` package with upstream `drupal/fontyourface` from drupal.org
- The YCloud fork only contained test compatibility fixes (PHP 8/D10+ compatibility) that have since been merged upstream

## Why this change
- Reduces maintenance burden of maintaining a fork
- Upstream package is now compatible with Drupal 10/11
- No code differences between fork and upstream (only package name and test fixes)

## Test plan
- [ ] Run `composer update drupal/fontyourface` on a test site
- [ ] Verify fontyourface module installs correctly
- [ ] Test font management functionality at `/admin/appearance/font`