### PR TITLE
Remove 'groupexpro' from installation types complete/custom

### DIFF
--- a/openy.installation_types.yml
+++ b/openy.installation_types.yml
@@ -43,7 +43,6 @@ complete:
     - editorial_ext
     - embeddable_header_footer
     - events
-    - groupexpro
     - helpers
     - locations
     - locations_ext


### PR DESCRIPTION
to fix error on site install 
<img width="1122" height="463" alt="Screenshot 2025-11-26 at 11 16 05" src="https://github.com/user-attachments/assets/7316df40-2af8-4bb4-abe2-591b2b1cc774" />
