### PR TITLE
feat: Support y_pef_schedule v2.1 with Drupal 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
     "open-y-subprojects/openy_hours_formatter": "^2.0 || ^3.0.0",
     "open-y-subprojects/openy_map": "^6@beta || ^6.0.0",
     "open-y-subprojects/ynorth_gxp_spots_proxy": "^1.0.1",
-    "ycloudyusa/y_pef_schedule": "^1.0",
+    "ycloudyusa/y_pef_schedule": "^1.0 || ^2.1",
     "ycloudyusa/useless_machines": "^2.0.3",
     "ycloudyusa/y_lb_demo_content": "^4@beta || ~4.0.0",
     "drupal/lb_testimonial_blocks": "^1.0",


### PR DESCRIPTION
## Summary
This PR updates the y_pef_schedule dependency constraint to support both v1.0 and v2.1.

## Changes
- Updated composer.json to allow  for y_pef_schedule dependency

## Why
The y_pef_schedule v2.1.1 release includes Drupal 11 support (https://github.com/YCloudYUSA/y_pef_schedule/releases/tag/2.1.1), which is required for sites upgrading to Drupal 11.

## Backward Compatibility
This change maintains full backward compatibility by allowing both v1.0 (Drupal 9/10) and v2.1 (Drupal 9/10/11) versions.