### PR TITLE
Add Drupal core patch for MenuTreeStorage performance (#3493290)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -339,7 +339,8 @@
       },
       "drupal/core": {
         "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch",
-        "InlineBlock LoggerInterface missing import https://www.drupal.org/node/3462504": "https://git.drupalcode.org/project/drupal/-/merge_requests/12460.diff"
+        "InlineBlock LoggerInterface missing import https://www.drupal.org/node/3462504": "https://git.drupalcode.org/project/drupal/-/merge_requests/12460.diff",
+        "Issue #3493290: Batch-load existing links in MenuTreeStorage::rebuild()": "https://git.drupalcode.org/project/drupal/-/merge_requests/14230.diff"
       },
       "drupal/video_embed_field": {
         "Allow creation of new Video Embed Field media entities using the Media Browser": "https://www.drupal.org/files/issues/2024-09-25/video_embed_field-3039873-45.patch"


### PR DESCRIPTION
## Summary

Add patch for [Drupal core issue #3493290](https://www.drupal.org/project/drupal/issues/3493290) to improve MenuTreeStorage performance during site installation.

## Patch

- **MR**: https://git.drupalcode.org/project/drupal/-/merge_requests/14230
- **Issue**: https://www.drupal.org/project/drupal/issues/3493290

## Performance Improvement

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `safeExecuteSelect` calls | 230,127 | 113,787 | **-50%** |
| Install time | 180 sec | 152 sec | **-15%** |

## Technical Details

The patch batch-loads existing menu links at the start of `rebuild()` instead of querying for each link individually in `doSave()`.

## Next Steps

After testing, please add RTBC comment to: https://www.drupal.org/project/drupal/issues/3493290#comment-16401655

## Test Plan

- [ ] Run `drush site:install` with patch applied
- [ ] Verify no errors in menu tree operations
- [ ] Confirm performance improvement