### PR TITLE
Add patch for Drupal #3492438 route rebuild optimization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -340,7 +340,8 @@
       "drupal/core": {
         "Url only outputs the last value of a query parameter": "https://www.drupal.org/files/issues/2024-02-28/3038774-51-10.2.3-reroll.patch",
         "InlineBlock LoggerInterface missing import https://www.drupal.org/node/3462504": "https://git.drupalcode.org/project/drupal/-/merge_requests/12460.diff",
-        "Issue #3493290: Batch-load existing links in MenuTreeStorage::rebuild()": "https://git.drupalcode.org/project/drupal/-/merge_requests/14230.diff"
+        "Issue #3493290: Batch-load existing links in MenuTreeStorage::rebuild()": "https://git.drupalcode.org/project/drupal/-/merge_requests/14230.diff",
+        "Issue #3492438: Reduce route rebuilds during module installation": "https://git.drupalcode.org/project/drupal/-/merge_requests/14231.diff"
       },
       "drupal/video_embed_field": {
         "Allow creation of new Video Embed Field media entities using the Media Browser": "https://www.drupal.org/files/issues/2024-09-25/video_embed_field-3039873-45.patch"


### PR DESCRIPTION
## Summary
- Adds Drupal core patch from [MR #14231](https://git.drupalcode.org/project/drupal/-/merge_requests/14231)
- Reduces unnecessary route rebuilds during module installation
- Related issue: https://www.drupal.org/project/drupal/issues/3492438

## Test plan
- [ ] Run `composer install` to verify patch applies cleanly
- [ ] Test module installation to verify routes work correctly