### PR TITLE
[FOR THE TEST] feat:Add global table styles for CKEditor content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -346,6 +346,9 @@
       },
       "drupal/video_embed_field": {
         "Allow creation of new Video Embed Field media entities using the Media Browser": "https://www.drupal.org/files/issues/2024-09-25/video_embed_field-3039873-45.patch"
+      },
+      "ycloudyusa/y_lb": {
+        "ITCR-1107: Add global table styles for CKEditor content": "https://patch-diff.githubusercontent.com/raw/YCloudYUSA/y_lb/pull/302.diff"
       }
     }
   },


### PR DESCRIPTION
PR: https://github.com/YCloudYUSA/y_lb/pull/302

Add consistent table styling across all Layout Builder components to ensure tables created via CKEditor Insert Table feature have uniform appearance regardless of the component they're placed in.

Changes:
- Add assets/css/tables.css with global table styles
- Update y_lb.libraries.yml to include tables.css in main library
- Bump main library version from 1.37 to 1.38

The styles apply to:
- Simple Text/Table component (lb_table)
- Tabs component (tab-content)
- Cards, Banner, and all other LB components with text fields
- All field types: text-with-summary, text-long, formatted text

Table styling includes:
- thead: 5px border-bottom, 22-24px font-size, bold
- tbody: 2px border-bottom, 18px font-size, 20px padding
- Responsive design with desktop breakpoint at 992px
- Uses CSS variables for colors (ylb-color-grey-2, ylb-color-light-grey-3)

Before (Tab component)
<img width="730" height="367" alt="image" src="https://github.com/user-attachments/assets/cb0c9bcc-0894-47d4-a71d-f7d8da5f9667" />

After:
<img width="762" height="447" alt="image" src="https://github.com/user-attachments/assets/2aef88f4-7984-44cd-b60b-db955470f1b5" />
