### PR TITLE
fix: move trash module install from hook_update to post_update

### DIFF
--- a/openy.install
+++ b/openy.install
@@ -1216,11 +1216,7 @@ function openy_update_11001() {
 }
 
 /**
- * Enable Trash module.
+ * Fix to unblock updates on some sites.
  */
 function openy_update_11002() {
-  // Check if already enabled to avoid errors.
-  if (!\Drupal::service('module_handler')->moduleExists('trash')) {
-    \Drupal::service('module_installer')->install(['trash']);
-  }
 }

--- a/openy.post_update.php
+++ b/openy.post_update.php
@@ -126,6 +126,15 @@ function openy_post_update_deprecate_entity_browser_media_directories() {
 }
 
 /**
+ * Enable Trash module.
+ */
+function openy_post_update_enable_trash() {
+  if (!\Drupal::service('module_handler')->moduleExists('trash')) {
+    \Drupal::service('module_installer')->install(['trash']);
+  }
+}
+
+/**
  * Migrate Media Directories vocabulary to Media Tags.
  *
  * Copies directory terms to media_tags vocabulary with same hierarchy,


### PR DESCRIPTION
## Summary
- Move trash module installation from `openy_update_11002` to `openy_post_update_enable_trash`
- Keep `openy_update_11002` as empty hook to not break update sequence
- `hook_update` runs before schema updates complete, causing router table errors on sites with outdated schema. `post_update` runs after all schema updates.

## Test plan
- [ ] Run `drush updb` on a site upgrading from YUSAOpenY 10.x to 11.3
- [ ] Verify trash module gets enabled
- [ ] Verify no router table errors