### PR TITLE
feat(ITCR-787): Add optional link field to testimonial_item for Read more functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -346,6 +346,12 @@
       },
       "drupal/video_embed_field": {
         "Allow creation of new Video Embed Field media entities using the Media Browser": "https://www.drupal.org/files/issues/2024-09-25/video_embed_field-3039873-45.patch"
+      },
+      "drupal/lb_testimonial_blocks": {
+        "Issue #3575365: Add optional link field to testimonial_item for Read more functionality": "https://git.drupalcode.org/project/lb_testimonial_blocks/-/merge_requests/27.diff"
+      },
+      "drupal/ws_small_y": {
+        "Issue #3575365: Add optional testimonial link to template": "https://git.drupalcode.org/project/ws_small_y/-/merge_requests/79.diff"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Adds `composer.json` patches for `drupal/lb_testimonial_blocks` and `drupal/ws_small_y` to bring in the optional testimonial link field feature
- `lb_testimonial_blocks` patch: adds `field_testimonial_link` (Link field with title) to `testimonial_item` block type, update hook `lb_testimonials_update_10002`, and JS truncation behavior
- `ws_small_y` patch: renders inline `<a class="testimonial-link">` inside the body `<p>` in the template

Related Drupal.org issue: https://www.drupal.org/project/lb_testimonial_blocks/issues/3575365

## Steps for review

- [ ] Run `composer install` and verify patches apply cleanly
- [ ] Go to Structure > Block layout > any page with Testimonials block
- [ ] Edit a `testimonial_item` — confirm the new optional **Link** field is visible in the form
- [ ] Add a link (URL + title, e.g. "Read more") and save
- [ ] Add a second testimonial item with a link and long body text
- [ ] Visit the page — confirm first carousel item shows `… Read more` inline if text overflows, or just `Read more` if text fits
- [ ] Click Next in the carousel — confirm second item also shows the link correctly
- [ ] Leave the Link field empty on a third item — confirm no link is rendered
- [ ] Run `drush updb` — confirm `lb_testimonials_update_10002` runs without errors and adds the field