### PR TITLE
fix: add composer patches for PHP 8.4/8.5 deprecations in contrib modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "drupal/plugin": "2.5 || ^2.8",
     "drupal/program_search": "^2.0.0",
     "drupal/protected_pages": "^1.4",
-    "drupal/rabbit_hole": "^1.1 || ^2.0@beta || ^2.0",
+    "drupal/rabbit_hole": "^1.1 || ^2.0",
     "drupal/recaptcha": "^3",
     "drupal/redirect": "^1",
     "drupal/responsive_favicons": "^2.0 || ^3.0",
@@ -348,7 +348,7 @@
         "Allow creation of new Video Embed Field media entities using the Media Browser": "https://www.drupal.org/files/issues/2024-09-25/video_embed_field-3039873-45.patch"
       },
       "drupal/rabbit_hole": {
-        "Issue #3516167: Fix PHP 8.4 implicit nullable parameter deprecations": "https://git.drupalcode.org/project/rabbit_hole/-/merge_requests/87.diff"
+        "Issue #3516167: Fix PHP 8.4 implicit nullable parameter deprecations": "https://git.drupalcode.org/project/rabbit_hole/-/merge_requests/82.diff"
       },
       "drupal/webform": {
         "Issue #3575614: PHP 8.5 deprecated case statement semicolon in WebformSubmissionForm": "https://git.drupalcode.org/project/webform/-/merge_requests/829.diff"


### PR DESCRIPTION
## Summary

Fixes PHP 8.4/8.5 deprecations in contrib modules generating ~235K deprecated function messages/day across YMCA sites.

| Module | msgs/day | Issue | Fix |
|--------|----------|-------|-----|
| rabbit_hole | ~192K | [#3516167](https://www.drupal.org/project/rabbit_hole/issues/3516167) implicit nullable params | Patch via [MR !82](https://git.drupalcode.org/project/rabbit_hole/-/merge_requests/82) (1.x fix) |
| field_group | ~23K | [#3504453](https://www.drupal.org/project/field_group/issues/3504453) implicit nullable params | Constraint upgraded to `^3.0 || ^4.0` — fix already released in 4.0.0 (2025-04-23) |
| webform | ~20K | [#3575614](https://www.drupal.org/project/webform/issues/3575614) `default;` → `default:` | Patch via [MR !829](https://git.drupalcode.org/project/webform/-/merge_requests/829.diff) |

Also updates:
- `drupal/rabbit_hole` constraint: `^1.0 || ^1.0@beta` → `^1.1 || ^2.0` (removed `@beta`)
- `drupal/field_group` constraint: `^3.0` → `^3.0 || ^4.0` (no patch needed — fix is in 4.0.0)
- `cweagans/composer-patches` constraint: `^1.0` → `^1.0 || ^2.0`

**Note on rabbit_hole patch**: With `prefer-stable: true`, Composer resolves rabbit_hole to 1.1.0 (stable) rather than 2.0.0-beta1 (beta). MR !82 is the 1.x equivalent of the same PHP 8.4 implicit nullable fix (MR !87 targets 2.x and does not apply to 1.x).

**google_tag**: already on 2.0.9 which includes the fix — no action needed.

## Test plan

- [x] Add yusaopeny as path repo in a test site, run `ddev composer update -W`
- [x] rabbit_hole 1.1.0 — MR !82 patch applies cleanly
- [x] field_group 4.0.0 installs (constraint `^3.0 || ^4.0`)
- [x] webform 6.3.0-beta7 — MR patch applies cleanly
- [x] `drush updb` + `drush cr` — no errors
- [ ] Confirm on staging after merge

Refs: ITCR-1129