### PR TITLE
Downgrade composer-patches version constraint in dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=8.3",
     "composer/installers": "^1.2",
-    "cweagans/composer-patches": "^1.0 || ^2.0",
+    "cweagans/composer-patches": "^1.0",
     "drupal/activenet": "^1.0",
     "drupal/address": "^1.8 || ^2.0",
     "drupal/addtoany": "^2.0",


### PR DESCRIPTION
after cweagans/composer-patches 2.0 we have issue:

<img width="1510" height="645" alt="Screenshot 2026-02-25 at 15 46 05" src="https://github.com/user-attachments/assets/c224dcd8-4d50-43c9-b2db-a3af8e4f2a9f" />

```In Patches.php line 288:

  No available patcher was able to apply patch https://www.drupal.org/files/i
  ssues/2022-08-09/hook-block-execute-3292520-14.patch to drupal/core
```

TODO investigate and fix.
