### PR TITLE
fix: remove breadcrumb block max-age=0 that breaks Dynamic Page Cache

### DIFF
--- a/openy.profile
+++ b/openy.profile
@@ -730,14 +730,6 @@ function openy_form_system_site_information_settings_alter(&$form, FormStateInte
  */
 function openy_preprocess_block(&$variables) {
   $variables['base_path'] = base_path();
-
-  // Prevent some blocks from caching.
-  $preventCacheBlocks = [
-    'system_breadcrumb_block',
-  ];
-  if (in_array($variables['plugin_id'], $preventCacheBlocks)) {
-    $variables['#cache']['max-age'] = 0;
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove the `max-age=0` override for `system_breadcrumb_block` in `openy_preprocess_block()` that was added in 2018 as a workaround for Drupal 8 breadcrumb caching issues (commit 433160ec7b2)

## Problem

`openy_preprocess_block()` sets `$variables['#cache']['max-age'] = 0` for the breadcrumb block. On Layout Builder pages, blocks render **without** `#lazy_builder`, so this `max-age=0` bubbles through the render tree directly to the page response. `DynamicPageCacheSubscriber` then marks the entire page as `UNCACHEABLE (poor cacheability)`, preventing both Dynamic Page Cache and any upstream CDN (e.g. CloudFlare) from caching the page.

This affects **all** Layout Builder content types that include a breadcrumb block (`lb_event`, `lb_article`, etc.).

On non-Layout Builder pages, the Block module uses `#lazy_builder` to isolate block rendering, so the `max-age=0` doesn't bubble up — which is why this bug only manifests on LB pages.

## Why the fix is safe

- `SystemBreadcrumbBlock::createPlaceholder()` returns `TRUE`, enabling auto-placeholdering in standard block rendering
- The breadcrumb builder already provides proper cache contexts (`route`), ensuring breadcrumbs vary correctly per page
- Drupal core's render caching handles breadcrumb invalidation through cache tags

## Test plan

- [ ] Visit a Layout Builder page with a breadcrumb block
- [ ] Check `X-Drupal-Dynamic-Cache` header: should be `MISS` on first request, `HIT` on second
- [ ] Verify breadcrumbs display correctly on different pages (not stale)
- [ ] Verify non-LB pages still cache correctly