### PR TITLE
feat(ITCR-800): Add patch for openy_node_alert location + Visibility Pages fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -361,6 +361,9 @@
       },
       "drupal/search_api": {
         "Issue #3564794: PHP 8.4 non-canonical casts (boolean)/(double) deprecated": "https://git.drupalcode.org/project/search_api/-/merge_requests/306.diff"
+      },
+      "open-y-subprojects/openy_node_alert": {
+        "ITCR-800: Allow location alerts to also show on Visibility Pages": "https://patch-diff.githubusercontent.com/raw/open-y-subprojects/openy_node_alert/pull/172.diff"
       }
     }
   },


### PR DESCRIPTION
## Problem

When an alert has both a **Location** and **Visibility Pages** ("Show for the listed pages") configured, the Visibility Pages setting is ignored. The alert only appears on the location's own page, not on the pages listed in Visibility Pages.

If the Location is removed, Visibility Pages work correctly.

### Steps to reproduce

1. Create an alert
2. Select any location
3. Add pages in Visibility Pages and select "Show for the listed pages"
4. Save the alert
5. Open one of the pages listed in Visibility Pages

**Current result:** The alert is not shown on the Visibility Pages — it only appears on the location's own page

**Expected result:** The alert should be shown on the pages listed in Visibility Pages (in addition to the location page)

## Solution

This PR adds a composer patch from [openy_node_alert PR #172](https://github.com/open-y-subprojects/openy_node_alert/pull/172) which fixes the filtering logic in `AlertManager::getAlerts()`.

Before the fix, location-based alerts were excluded before `checkVisibility()` was ever reached on non-location pages. The fix allows a location alert through if it passes the Visibility Pages check for the current page.