### PR TITLE
feat: add admin_toolbar performance patch for module install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -313,7 +313,8 @@
     ],
     "patches": {
       "drupal/admin_toolbar": {
-        "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch"
+        "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
+        "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"
       },
       "drupal/ckeditor5_font": {
         "Issue #3368736: no config schema' Error after update to Drupal 10.1.0": "https://www.drupal.org/files/issues/2024-06-25/ckeditor5_font-schema-fix-10.3.x-3368736-48_0.patch",


### PR DESCRIPTION
## Summary

- Adds patch from [MR !209](https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209) (drupal.org [issue #3385337](https://www.drupal.org/project/admin_toolbar/issues/3385337))
- Defers menu link rebuilds during module installation via `DestructableInterface`, executing a single rebuild at request termination instead of hundreds
- Batch-preloads routes in `ExtraLinks::routeExists()` to avoid triggering route rebuilds on every call

## Test plan

- [ ] `drush en dblog -y` completes in <10s (was hanging indefinitely)
- [ ] `drush en openy_memberships openy_memberships_front -y` completes in <90s
- [ ] Admin toolbar still works correctly after module install