### PR TITLE
fix: bump openy_custom minimum version to ^3.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
     "oomphinc/composer-installers-extender": "^1.1 || ^2.0.0",
     "open-y-subprojects/common_scss": "dev-main",
     "open-y-subprojects/openy_content_core": "^3.0",
-    "open-y-subprojects/openy_custom": "^3.1.3",
+    "open-y-subprojects/openy_custom": "^3.1.4",
     "open-y-subprojects/openy_daxko_gxp_syncer": "^1.2",
     "open-y-subprojects/openy_features": "^5.0",
     "open-y-subprojects/openy_focal_point": "^2.0",


### PR DESCRIPTION
## Summary
- Bumps `open-y-subprojects/openy_custom` constraint from `^3.0.0` to `^3.1.3`
- Prevents silent downgrade to 3.0.4 during PR builder runs

## Problem
When PR builder runs `composer require ycloudyusa/yusaopeny:dev-<branch> -W`, the dev branch has no numeric version. `openy_custom` 3.1.3 requires `ycloudyusa/yusaopeny > 11.1.0.0`, which a dev branch doesn't satisfy. Composer silently downgrades to 3.0.4 (which lacks this constraint).

## Fix
By requiring `^3.1.3`, composer can no longer silently downgrade to 3.0.x. The PR builder should also use version aliases (e.g. `dev-branch as 11.3.x`) to properly satisfy version constraints.