### PR TITLE
fix: add patches for simple_menu_icons theme hook and CSS aggregation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=8.3",
     "composer/installers": "^1.2",
-    "cweagans/composer-patches": "^1 || ^2",
+    "cweagans/composer-patches": "^1",
     "drupal/activenet": "^1.0",
     "drupal/address": "^1.8 || ^2.0",
     "drupal/addtoany": "^2.0",


### PR DESCRIPTION
## Summary
- Adds patch for [#3525231](https://www.drupal.org/project/simple_menu_icons/issues/3525231): **Theme hook simple_menu_icons_css_item not found** — `hook_rebuild()` executes before `hook_theme()`, causing theme hook to be unavailable during CSS generation. Fix defers CSS file creation to `hook_css_alter()`.
- Adds patch for [#3026947](https://www.drupal.org/project/simple_menu_icons/issues/3026947): **CSS not included when CSS aggregation is activated in production mode** — icons not displayed when Drupal CSS aggregation is enabled. Fix removes CSS file prefixes that break aggregation.

## Test plan
- [ ] Install YUSAOpenY with `simple_menu_icons` enabled
- [ ] Verify no "Theme hook simple_menu_icons_css_item not found" errors in logs
- [ ] Enable CSS aggregation in `/admin/config/development/performance`
- [ ] Verify menu icons still display correctly with aggregation on