### PR TITLE
feat: bump openy_carnation minimum to ^4.0.0-beta6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "drupal/migrate_source_csv": "^3",
     "drupal/migrate_tools": "^5.0 || ^6",
     "drupal/openy_branch_selector": "^1.0.3",
-    "drupal/openy_carnation": "^4.0.0-beta3 || ^4.0@rc || ^4.0.0",
+    "drupal/openy_carnation": "^4.0.0-beta6 || ^4.0@rc || ^4.0.0",
     "drupal/openy_daxko2": "^1.0",
     "drupal/openy_er": "^1.0",
     "drupal/openy_gtranslate": "^1 || ^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -312,6 +312,9 @@
       "openy-docs"
     ],
     "patches": {
+      "drupal/openy_carnation": {
+        "fix: restore join fee display in membership calculator step 3 - MR#122": "https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff"
+      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"


### PR DESCRIPTION
## Summary

- Bumps `drupal/openy_carnation` minimum version from `^4.0.0-beta3` to `^4.0.0-beta6`

## Why

`4.0.0-beta6` includes the fix for tab pane link color: links inside `.tab-pane` were showing in body text color instead of the theme link color due to a CSS specificity issue (`color: inherit` at 0,1,1 vs `a { color: $link-color }` at 0,0,1).

- drupal.org release: https://www.drupal.org/project/openy_carnation/releases/4.0.0-beta6
- MR: https://git.drupalcode.org/project/openy_carnation/-/merge_requests/121

## Test plan

- [ ] `composer update drupal/openy_carnation` resolves to `4.0.0-beta6`
- [ ] Links in tab panes display in the correct theme link color