### PR TITLE
fix(ITCR-1151): add composer patch for openy_carnation join fee fix (MR#122)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -312,6 +312,9 @@
       "openy-docs"
     ],
     "patches": {
+      "drupal/openy_carnation": {
+        "fix: restore join fee display in membership calculator step 3 - MR#122": "https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff"
+      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"

--- a/composer.json
+++ b/composer.json
@@ -315,6 +315,9 @@
       "drupal/openy_carnation": {
         "fix: restore join fee display in membership calculator step 3 - MR#122": "https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff"
       },
+      "open-y-subprojects/openy_custom": {
+        "fix: join-fee font size in membership calc - PR#97": "https://patch-diff.githubusercontent.com/raw/open-y-subprojects/openy_custom/pull/97.diff"
+      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"


### PR DESCRIPTION
## Summary
- Adds composer patch for `drupal/openy_carnation` MR#122
- Fixes join fee not displaying on step 3 of Membership Calculator
- Patch URL: https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff

## Test plan
- [ ] Enable membership calculator on a YMCA site
- [ ] Create a membership node with Join Fee set
- [ ] Go through calculator steps 1-2
- [ ] On step 3 verify both Monthly rate and Join Fee are displayed