### PR TITLE
fix: purge orphaned field data after groupex_pro uninstall

### DIFF
--- a/openy.post_update.php
+++ b/openy.post_update.php
@@ -332,8 +332,13 @@ function openy_post_update_uninstall_google_analytics() {
  * field_purge_batch() to clean up the remaining field definitions and storage.
  */
 function openy_post_update_purge_groupex_field_data() {
-  $deleted_repo = \Drupal::service('entity_field.deleted_fields_repository');
-  $definitions = $deleted_repo->getFieldDefinitions();
+  try {
+    $deleted_repo = \Drupal::service('entity_field.deleted_fields_repository');
+    $definitions = $deleted_repo->getFieldDefinitions();
+  }
+  catch (\Exception $e) {
+    return 'Could not load deleted fields repository: ' . $e->getMessage();
+  }
 
   $has_orphaned_data = FALSE;
   foreach ($definitions as $definition) {
@@ -348,10 +353,13 @@ function openy_post_update_purge_groupex_field_data() {
   }
 
   $db = \Drupal::database();
-  $tables = $db->query("SHOW TABLES LIKE 'field_deleted_%'")->fetchCol();
+  $schema = $db->schema();
+  $tables = $schema->findTables('field_deleted_%');
 
-  foreach ($tables as $table) {
-    $db->truncate($table)->execute();
+  if (!empty($tables)) {
+    foreach ($tables as $table) {
+      $db->truncate($table)->execute();
+    }
   }
 
   field_purge_batch(500);

--- a/openy.post_update.php
+++ b/openy.post_update.php
@@ -318,3 +318,43 @@ function openy_post_update_uninstall_google_analytics() {
 
   return 'google_analytics module uninstalled. Configure google_tag at /admin/config/services/google_tag.';
 }
+
+/**
+ * Purge orphaned field data left after groupex_pro modules were uninstalled.
+ *
+ * When openy_prgf_group_schedules was uninstalled, its field
+ * field_prgf_schedules_ref (type plugin:block) was marked for deletion.
+ * The field_purge_batch() called during cron fails with a TypeError because
+ * the plugin module receives a serialized string instead of an array for the
+ * plugin_configuration column. This blocks cron on all affected sites.
+ *
+ * Fix: truncate the orphaned deleted field data tables, then run
+ * field_purge_batch() to clean up the remaining field definitions and storage.
+ */
+function openy_post_update_purge_groupex_field_data() {
+  $deleted_repo = \Drupal::service('entity_field.deleted_fields_repository');
+  $definitions = $deleted_repo->getFieldDefinitions();
+
+  $has_orphaned_data = FALSE;
+  foreach ($definitions as $definition) {
+    if ($definition->getName() === 'field_prgf_schedules_ref') {
+      $has_orphaned_data = TRUE;
+      break;
+    }
+  }
+
+  if (!$has_orphaned_data) {
+    return 'No orphaned groupex_pro field data found.';
+  }
+
+  $db = \Drupal::database();
+  $tables = $db->query("SHOW TABLES LIKE 'field_deleted_%'")->fetchCol();
+
+  foreach ($tables as $table) {
+    $db->truncate($table)->execute();
+  }
+
+  field_purge_batch(500);
+
+  return 'Purged orphaned field data from removed groupex_pro modules.';
+}


### PR DESCRIPTION
## Summary
- After `openy_prgf_group_schedules` is uninstalled, its field `field_prgf_schedules_ref` (type `plugin:block`) is marked for deletion
- `field_purge_batch()` during cron fails with `TypeError: PluginCollectionItemBase::setContainedPluginConfiguration(): Argument #1 ($configuration) must be of type array, string given`
- The `plugin_configuration` blob column contains serialized PHP strings that aren't properly deserialized during field purge
- This **blocks cron on ALL sites** where groupex_pro modules were removed

## Fix
Add `openy_post_update_purge_groupex_field_data()` that:
1. Checks if orphaned `field_prgf_schedules_ref` field definitions exist
2. Truncates all `field_deleted_*` data tables to bypass the serialization issue
3. Runs `field_purge_batch(500)` to clean up field definitions and storage

## Test plan
- Import a database from a site where groupex_pro was removed and cron is failing
- Run `drush updb -y` — post_update should execute successfully
- Run `drush cron` — should complete without errors
- Verify: `drush sqlq "SHOW TABLES LIKE 'field_deleted_%'"` — no orphaned tables remain