### PR TITLE
fix: patch entity_reference_revisions for content moderation save error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -362,6 +362,9 @@
       },
       "drupal/search_api": {
         "Issue #3564794: PHP 8.4 non-canonical casts (boolean)/(double) deprecated": "https://git.drupalcode.org/project/search_api/-/merge_requests/306.diff"
+      },
+      "drupal/entity_reference_revisions": {
+        "Issue #3571637: Fix EntityStorageException when saving paragraphs with content moderation": "https://git.drupalcode.org/project/entity_reference_revisions/-/merge_requests/90.diff"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Adds composer patch for `drupal/entity_reference_revisions` from [MR #90](https://git.drupalcode.org/project/entity_reference_revisions/-/merge_requests/90)
- Fixes `EntityStorageException: An existing default revision of the 'paragraph' entity type can not be changed to a non-default revision` when saving nodes with paragraphs under content moderation
- Drupal 11.x core added validation ([#3499181](https://www.drupal.org/project/drupal/issues/3499181)) that disallows saving a default revision as non-default without creating a new revision.

## Test plan
- [ ] Install on a site with paragraphs + content moderation enabled
- [ ] Edit a Published node with paragraphs and click Save without changes
- [ ] Verify no "The content could not be saved" error
- [ ] Create a draft of a published node, verify paragraphs save correctly