### PR TITLE
fix: add composer patch for SVG upload support in openy_focal_point

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -362,6 +362,9 @@
       },
       "drupal/search_api": {
         "Issue #3564794: PHP 8.4 non-canonical casts (boolean)/(double) deprecated": "https://git.drupalcode.org/project/search_api/-/merge_requests/306.diff"
+      },
+      "open-y-subprojects/openy_focal_point": {
+        "Allow SVG uploads when svg is listed in field extensions - PR#7": "https://patch-diff.githubusercontent.com/raw/open-y-subprojects/openy_focal_point/pull/7.diff"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
     "drupal/simple_menu_icons": "^2.2 || ^3",
     "drupal/simple_sitemap": "^3.7 || ^4.1",
     "drupal/slick": "^2 || ^3.0",
-    "drupal/svg_image": "^3.2",
     "drupal/slick_views": "^2 || ^3.0",
     "drupal/ws_small_y": "^2.0",
     "drupal/social_feed_fetcher": "^3.1",
@@ -126,7 +125,7 @@
     "open-y-subprojects/openy_custom": "^3.1.4",
     "open-y-subprojects/openy_daxko_gxp_syncer": "^1.2",
     "open-y-subprojects/openy_features": "^5.0",
-    "open-y-subprojects/openy_focal_point": "^2.0",
+    "open-y-subprojects/openy_focal_point": "^2.1",
     "open-y-subprojects/openy_hours_formatter": "^2.0 || ^3.0.0",
     "open-y-subprojects/openy_map": "^6@beta || ^6.0.0",
     "open-y-subprojects/ynorth_gxp_spots_proxy": "^1.0.1",
@@ -363,9 +362,6 @@
       },
       "drupal/search_api": {
         "Issue #3564794: PHP 8.4 non-canonical casts (boolean)/(double) deprecated": "https://git.drupalcode.org/project/search_api/-/merge_requests/306.diff"
-      },
-      "open-y-subprojects/openy_focal_point": {
-        "Allow SVG uploads when svg is listed in field extensions - PR#7": "https://patch-diff.githubusercontent.com/raw/open-y-subprojects/openy_focal_point/pull/7.diff"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
     "drupal/simple_menu_icons": "^2.2 || ^3",
     "drupal/simple_sitemap": "^3.7 || ^4.1",
     "drupal/slick": "^2 || ^3.0",
+    "drupal/svg_image": "^3.2",
     "drupal/slick_views": "^2 || ^3.0",
     "drupal/ws_small_y": "^2.0",
     "drupal/social_feed_fetcher": "^3.1",


### PR DESCRIPTION
## Problem

Uploading SVG files via \`/media/add/image\` fails with:

> The selected file example.svg cannot be uploaded. Only files with the following extensions are allowed: png, gif, jpg, jpeg.

This happens even when \`svg\` is explicitly listed in the image field's \`file_extensions\` setting at \`/admin/structure/media/manage/image/fields/media.image.field_media_image\`.

**Root cause:** \`ImageWidget::formElement()\` (core \`image\` module) intersects \`file_extensions\` with \`\$this->imageFactory->getSupportedExtensions()\`. The GD toolkit does not support SVG because it is a vector format, so \`svg\` gets stripped out of the allowed extensions list before the \`FileExtension\` validator runs — regardless of what is configured on the field.

The \`svg_image\` module fixes this for the core \`image_image\` widget via \`hook_field_widget_info_alter\`, but the \`OpenYFocalPointImageWidget\` extends \`FocalPointImageWidget\` → \`ImageWidget\` and is not covered by that override.

## Solution

Apply the patch from [open-y-subprojects/openy_focal_point#7](https://github.com/open-y-subprojects/openy_focal_point/pull/7) as a composer patch on \`open-y-subprojects/openy_focal_point\` until it is merged and released in a new version.

The patch overrides \`formElement()\` in \`OpenYFocalPointImageWidget\` to:
1. Re-add \`svg\` to the \`FileExtension\` validator extensions
2. Remove the \`FileIsImage\` validator (GD cannot process vector files)

Both changes apply **only** when \`svg\` is explicitly listed in the field's \`file_extensions\` setting, so existing behavior is unchanged for fields that do not allow SVG.

## Testing

**Prerequisites:**
- YUSAOpenY site with \`openy_focal_point\` module enabled
- \`svg\` added to allowed extensions on the media Image field: \`/admin/structure/media/manage/image/fields/media.image.field_media_image\`

**Steps:**

1. Install dependencies: \`composer install\`
2. Enable modules: \`drush en svg_image -y && drush cr\`
3. Go to \`/media/add/image\`
4. Click **Choose file** and select any \`.svg\` file
5. Fill in the **Alternative text** field
6. Click **Save**

**Expected result:** Media entity is created and the SVG file is visible in the media library.

**Before this patch:** Upload fails with _"The selected file ... cannot be uploaded. Only files with the following extensions are allowed: png, gif, jpg, jpeg."_

**Regression check:** Upload a regular \`.jpg\` or \`.png\` — should work as before with focal point controls visible.