### PR TITLE
fix(ITCR-1151): bump versions for join-fee fixes (drop patches)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -312,6 +312,9 @@
       "openy-docs"
     ],
     "patches": {
+      "drupal/openy_carnation": {
+        "fix: restore join fee display in membership calculator step 3 - MR#122": "https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff"
+      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "drupal/migrate_source_csv": "^3",
     "drupal/migrate_tools": "^5.0 || ^6",
     "drupal/openy_branch_selector": "^1.0.3",
-    "drupal/openy_carnation": "^4.0.0-beta3 || ^4.0@rc || ^4.0.0",
+    "drupal/openy_carnation": "^4.0.0-beta7 || ^4.0@rc || ^4.0.0",
     "drupal/openy_daxko2": "^1.0",
     "drupal/openy_er": "^1.0",
     "drupal/openy_gtranslate": "^1 || ^2.0.0",
@@ -122,7 +122,7 @@
     "oomphinc/composer-installers-extender": "^1.1 || ^2.0.0",
     "open-y-subprojects/common_scss": "dev-main",
     "open-y-subprojects/openy_content_core": "^3.0",
-    "open-y-subprojects/openy_custom": "^3.1.4",
+    "open-y-subprojects/openy_custom": "^3.1.5",
     "open-y-subprojects/openy_daxko_gxp_syncer": "^1.2",
     "open-y-subprojects/openy_features": "^5.0",
     "open-y-subprojects/openy_focal_point": "^2.0",
@@ -312,12 +312,6 @@
       "openy-docs"
     ],
     "patches": {
-      "drupal/openy_carnation": {
-        "fix: restore join fee display in membership calculator step 3 - MR#122": "https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff"
-      },
-      "open-y-subprojects/openy_custom": {
-        "fix: join-fee font size in membership calc - PR#97": "https://patch-diff.githubusercontent.com/raw/open-y-subprojects/openy_custom/pull/97.diff"
-      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"

--- a/composer.json
+++ b/composer.json
@@ -315,6 +315,9 @@
       "drupal/openy_carnation": {
         "fix: restore join fee display in membership calculator step 3 - MR#122": "https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122.diff"
       },
+      "open-y-subprojects/openy_custom": {
+        "fix: join-fee font size in membership calc - PR#97": "https://patch-diff.githubusercontent.com/raw/open-y-subprojects/openy_custom/pull/97.diff"
+      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"


### PR DESCRIPTION
## Problem

Membership calculator step 3 has two visual regressions:

1. **Join fee not displayed** — the join fee amount is hidden in step 3 of the membership calculator, leaving members unable to see the full cost breakdown before confirming.
2. **Join fee font size mismatch** — when join fee is shown, its font size does not match the monthly rate, breaking the visual hierarchy.

## Fix

Both fixes have landed in upstream releases — composer patches removed, minimum versions bumped:

- `drupal/openy_carnation` `^4.0.0-beta3` → `^4.0.0-beta7`
  Includes [MR#122](https://git.drupalcode.org/project/openy_carnation/-/merge_requests/122): restore join fee display in membership calculator step 3
- `open-y-subprojects/openy_custom` `^3.1.4` → `^3.1.5`
  Includes [PR#97](https://github.com/open-y-subprojects/openy_custom/pull/97): fix join-fee font size to match monthly rate layout

## Test plan

- [ ] Open membership calculator and proceed to step 3
- [ ] Verify join fee amount is visible in the cost breakdown
- [ ] Verify join fee font size matches the monthly rate font size
- [ ] Verify no visual regressions in steps 1 and 2 of the calculator