### PR TITLE
Opt syncer-owned node bundles out of Trash by default

### DIFF
--- a/openy.install
+++ b/openy.install
@@ -1220,3 +1220,22 @@ function openy_update_11001() {
  */
 function openy_update_11002() {
 }
+
+/**
+ * Opt syncer-owned bundles out of Trash on existing sites.
+ *
+ * Mirrors the openy_install_finish step that runs on fresh installs.
+ * session, activity, class, program, program_subcategory are removed
+ * from trash.settings.enabled_entity_types.node so the schedule syncers
+ * (Daxko, GroupEx Pro, YMCA360, Traction Rec, …) don't keep re-creating
+ * soft-deleted occurrences. No-op when Trash is not enabled.
+ */
+function openy_update_11003(): string {
+  // The helper lives in the profile file; load it explicitly because
+  // hook_update_N runs without the profile bootstrap that .profile
+  // gets during install.
+  $profile_path = \Drupal::service('extension.list.profile')->getPath('openy');
+  require_once $profile_path . '/openy.profile';
+  openy_optout_syncer_bundles_from_trash();
+  return 'Syncer-owned bundles excluded from Trash where applicable.';
+}

--- a/openy.profile
+++ b/openy.profile
@@ -608,6 +608,41 @@ function openy_install_finish(array &$install_state) {
     $view->disable();
     $view->save();
   }
+  openy_optout_syncer_bundles_from_trash();
+}
+
+/**
+ * Opts syncer-owned node bundles out of Trash by default.
+ *
+ * Bundles created and removed in lockstep with upstream APIs (Daxko,
+ * GroupEx Pro, YMCA360, Traction Rec, …) — session, activity, class,
+ * program, program_subcategory — should not be soft-deleted by the
+ * Trash module: each sync would re-create them as orphans the next
+ * run. Operators can re-enable Trash for any of these bundles via the
+ * Trash settings UI.
+ *
+ * Runs at the very end of profile install (openy_install_finish), when
+ * every Open Y bundle module has finished installing, so the bundle
+ * list expansion is complete and unrelated bundles are preserved.
+ */
+function openy_optout_syncer_bundles_from_trash(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('trash')) {
+    return;
+  }
+  $opt_out = ['session', 'activity', 'class', 'program', 'program_subcategory'];
+  $config = \Drupal::configFactory()->getEditable('trash.settings');
+  $enabled = $config->get('enabled_entity_types') ?? [];
+  if (!array_key_exists('node', $enabled)) {
+    return;
+  }
+  if ($enabled['node'] === []) {
+    $bundles = array_keys(\Drupal::service('entity_type.bundle.info')->getBundleInfo('node'));
+    $enabled['node'] = array_values(array_diff($bundles, $opt_out));
+  }
+  else {
+    $enabled['node'] = array_values(array_diff($enabled['node'], $opt_out));
+  }
+  $config->set('enabled_entity_types', $enabled)->save();
 }
 
 /**


### PR DESCRIPTION
## Summary

`session`, `activity`, `class`, `program`, `program_subcategory` are owned by schedule syncers (Daxko, GroupEx Pro, YMCA360, Traction Rec, …) that create and remove these nodes in lockstep with their upstream APIs. Letting Trash soft-delete them produces a growing backlog the next sync re-creates as orphans.

The fix lives at the profile level — \`openy_install_finish\` runs after every Open Y bundle module has finished installing, so the bundle-list expansion is complete and unrelated bundles stay tracked.

## Changes

- New helper \`openy_optout_syncer_bundles_from_trash()\` that:
  - expands the empty-array shorthand for \`trash.settings.enabled_entity_types.node\` into an explicit list of current bundles minus the opt-out set, or
  - trims the opt-out names from an existing non-empty list.
  - is a no-op when Trash is not enabled or the node entity type isn't tracked.
- Helper invoked from \`openy_install_finish\` (immediately after the frontpage view is disabled).

Operators who want Trash for any of these bundles can re-enable them via the Trash settings UI.

## Test plan

Fresh \`drush si openy\` with Trash enabled in the codebase:

\`\`\`yaml
trash.settings:enabled_entity_types:
  node:
    - alert
    - article_lb
    - branch
    - camp
    - camp_lp
    - facility
    - landing_page
    - landing_page_lb
    - lb_event
\`\`\`

5 syncer-owned bundles are excluded; the 9 unrelated bundles are tracked as before.

## Why profile-level

Per-module \`hook_install\` was racy: when an early \`openy_node_*\` install ran, later \`openy_loc_*\` bundles didn't yet exist, so expanding \`{}\` produced an incomplete list and \`camp\` / \`camp_lp\` / \`facility\` quietly fell out of Trash. Doing it once in \`openy_install_finish\` avoids that.