### PR TITLE
feat: add yusaopeny_ymca360 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,6 +135,7 @@
     "ycloudyusa/y_lb": "^5.0",
     "ycloudyusa/y_lb_demo_content": "^5.0",
     "ycloudyusa/yusaopeny_activity_finder": "^6.0",
+    "ycloudyusa/yusaopeny_ymca360": "^2.0",
     "ymcatwincities/media_entity_document": "*",
     "drupal/ymca_sync": "^10 || ^11",
     "ycloudyusa/ws_outsiders": "dev-main",


### PR DESCRIPTION
## Summary
- Add `ycloudyusa/yusaopeny_ymca360: ^2.0` to `require` so the YMCA360 integration ships with the distribution out of the box.
- Package: https://packagist.org/packages/ycloudyusa/yusaopeny_ymca360 (latest stable 2.1.0).
- Source: https://github.com/YCloudYUSA/yusaopeny_ymca360

## Test plan
- [ ] `composer validate`
- [ ] `composer update ycloudyusa/yusaopeny_ymca360 -W` resolves without conflicts
- [ ] Fresh install of the profile enables successfully with the module available