### PR TITLE
fix: bump drupal/recaptcha constraint to ^3.5@RC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     "drupal/program_search": "^2.0.0",
     "drupal/protected_pages": "^1.4",
     "drupal/rabbit_hole": "^1.1 || ^2.0",
-    "drupal/recaptcha": "^3",
+    "drupal/recaptcha": "^3.5@RC",
     "drupal/redirect": "^1",
     "drupal/responsive_favicons": "^2.0 || ^3.0",
     "drupal/scheduler": "^2 || ^2.0@RC",


### PR DESCRIPTION
## Summary
Raise the floor on `drupal/recaptcha` from `^3` to `^3.5@RC` so YUSAOpenY installs ship the fixed `Drupal8Post::submit()` signature.

## Problem
`drupal/recaptcha` < 3.5.0-rc1 declares:

```php
public function submit(RequestParameters $params)
```

Upstream `google/recaptcha` (already required transitively) bumped the interface to:

```php
public function submit(RequestParameters $params): string
```

Result on form submit when reCAPTCHA v2 is enabled:

```
Fatal error: Declaration of Drupal\recaptcha\ReCaptcha\RequestMethod\Drupal8Post::submit(ReCaptcha\RequestParameters $params)
must be compatible with ReCaptcha\RequestMethod::submit(ReCaptcha\RequestParameters $params): string
in docroot/modules/contrib/recaptcha/src/ReCaptcha/RequestMethod/Drupal8Post.php on line 39
```

## Fix
`drupal/recaptcha` 8.x-3.5-rc1 ([release](https://www.drupal.org/project/recaptcha/releases/8.x-3.5-rc1)) adds the `: string` return type to `Drupal8Post::submit()`. Bumping the constraint to `^3.5@RC` allows installs to pick up the fix while staying inside the 3.x line.

## Test plan
- [ ] `composer update drupal/recaptcha -W` on a YUSAOpenY install resolves to `3.5.0-rc1` (or later)
- [ ] Enable reCAPTCHA v2 on a webform / contact form
- [ ] Submit form → no fatal, no signature compatibility error