### PR TITLE
Release 11.3.1.5

### DIFF
--- a/openy.info.yml
+++ b/openy.info.yml
@@ -1,7 +1,7 @@
 name: YMCA Website Services
 type: profile
 description: 'YMCA Website Services Drupal 11+ distribution.'
-version: '11.3.1.4-dev'
+version: '11.3.1.5'
 core_version_requirement: ^11.1 || ^11.3
 distribution:
   name: YMCA Website Services


### PR DESCRIPTION
## Summary

Patch release. Bumps `openy.info.yml` `version` from `11.3.1.4-dev` to `11.3.1.5`.

## Changes since 11.3.1.4

- **#369** — bump `drupal/recaptcha` constraint to `^3.5@RC`. Picks up the `Drupal8Post::submit(): string` signature fix matching upstream `google/recaptcha`. Resolves the fatal `Declaration must be compatible` on form submit when reCAPTCHA v2 is enabled.

## Test plan

- [ ] `composer update drupal/recaptcha -W` resolves to `3.5.0-rc1` or later
- [ ] Enable reCAPTCHA v2 on a webform or contact form
- [ ] Submit the form — no signature-compatibility fatal
- [ ] `admin/reports/status` shows YMCA Website Services 11.3.1.5

## Next steps after merge

1. Tag `11.3.1.5` on `main` and publish GitHub release.
2. Open a follow-up PR bumping `openy.info.yml` back to `11.3.1.6-dev`.
3. Refresh the `openy.cibox.tools` private mirror.
4. Announce in `#developers` and `#general` Slack channels.
5. Add release notes to `yusaopeny_docs` (`content/en/blog/releases/release-ds-11.3.1.5.md`).