### PR TITLE
chore: bump version to 11.3.1.6-dev

### DIFF
--- a/openy.info.yml
+++ b/openy.info.yml
@@ -1,7 +1,7 @@
 name: YMCA Website Services
 type: profile
 description: 'YMCA Website Services Drupal 11+ distribution.'
-version: '11.3.1.5'
+version: '11.3.1.6-dev'
 core_version_requirement: ^11.1 || ^11.3
 distribution:
   name: YMCA Website Services


### PR DESCRIPTION
Post-release bump after 11.3.1.5 tag. Sets `openy.info.yml` version to `11.3.1.6-dev` for ongoing development.