### PR TITLE
fix(ITCP-659): add lb_cards patch for button gap in equal-height card rows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -313,6 +313,9 @@
       "openy-docs"
     ],
     "patches": {
+      "drupal/lb_cards": {
+        "Fix button gap in equal-height card rows (MR !58)": "https://git.drupalcode.org/project/lb_cards/-/merge_requests/58.diff"
+      },
       "drupal/admin_toolbar": {
         "Issue #3335841 - Admin toolbar menu z-index increase": "https://www.drupal.org/files/issues/2023-02-06/3335841-2.patch",
         "Issue #3385337 - Defer menu link rebuilds to reduce queries during module install": "https://git.drupalcode.org/project/admin_toolbar/-/merge_requests/209.diff"


### PR DESCRIPTION
## Problem

Excessive vertical indentation between description and CTA button in `lb_cards` components when cards in the same row have different amounts of content.

Root cause: Bootstrap's `.card-body { flex: 1 1 auto }` makes `card-body` fill all available height in the flex-column `card-content`. Combined with `h-100` on `card-content` and `height: 100%` on the card, the button gets pushed far from the description text on shorter cards.

## Solution

Applies [lb_cards MR !58](https://git.drupalcode.org/project/lb_cards/-/merge_requests/58) as a composer patch until it is merged and released.

Changes in the patch:
- `flex-shrink: 0` on `.card-img-wrapper` — prevents image from compressing
- `flex: 1 0 auto` on `.card-content` — fills remaining card space after image (replaces `h-100`)
- `flex: 0 0 auto` on `.card-body` — overrides Bootstrap `flex: 1 1 auto`
- `margin-top: auto` on `.card-footer` — pins button to bottom of card
- `aspect-ratio: 540/408` on chevron (was `540/508`)
- Removes `h-100` from `card-content` in twig template

## Test plan

- [ ] Install yusaopeny with `small_y` or `standard` preset
- [ ] Add `lb_cards` block and test **chevron** variation:
  - [ ] Add cards with different amounts of text (short vs long title/description)
  - [ ] Verify buttons align at the bottom across all cards in the same row
  - [ ] Verify no excessive gap between description and button on shorter cards
  - [ ] Check image area renders correctly with new `aspect-ratio: 540/408`
- [ ] Test **standard** variation (no chevron):
  - [ ] Verify same button alignment behavior
  - [ ] Verify image area with `aspect-ratio: 540/333` is unaffected
- [ ] Test **color** variation (no chevron):
  - [ ] Verify same button alignment behavior
  - [ ] Verify image area with `aspect-ratio: 540/400` is unaffected
- [ ] Verify 1-column layout (horizontal card) still works correctly for all variations