### PR TITLE
chore: remove deprecated CKEditor 4 library plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,9 +106,6 @@
     "grt107/grt-youtube-popup": "^1.0",
     "guzzlehttp/guzzle": "^6 || ^7",
     "league/csv": "^9.11.0 !=9.12.0",
-    "library-ckeditor/colorbutton": "4.10.1",
-    "library-ckeditor/font": "4.12.1",
-    "library-ckeditor/panelbutton": "4.10.1",
     "library-davekoelle/alphanum": "1.0.0",
     "library-jaypan/jquery_colorpicker": "1.0.1",
     "library-smonetti/btbutton": "1.0.2",
@@ -175,44 +172,8 @@
       }
     },
     {
-      "type": "package",
-      "package": {
-        "name": "library-ckeditor/panelbutton",
-        "type": "drupal-library",
-        "version": "4.10.1",
-        "dist": {
-          "type": "zip",
-          "url": "https://download.ckeditor.com/panelbutton/releases/panelbutton_4.10.1.zip"
-        }
-      }
-    },
-    {
       "type": "git",
       "url": "https://github.com/open-y-subprojects/openy_docs"
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "library-ckeditor/colorbutton",
-        "type": "drupal-library",
-        "version": "4.10.1",
-        "dist": {
-          "type": "zip",
-          "url": "https://download.ckeditor.com/colorbutton/releases/colorbutton_4.10.1.zip"
-        }
-      }
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "library-ckeditor/font",
-        "type": "drupal-library",
-        "version": "4.12.1",
-        "dist": {
-          "type": "zip",
-          "url": "https://download.ckeditor.com/font/releases/font_4.12.1.zip"
-        }
-      }
     },
     {
       "type": "package",


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge this PR first.** Paired with YCloudYUSA/yusaopeny-project#71, which removes the matching `repositories` declarations from the project template.
> Merge **this PR (#374) first**, then #71. Reversing the order breaks `composer install`.

## What

Removes all deprecated CKEditor 4 library plugins from the distribution:

- `library-ckeditor/font` (4.12.1)
- `library-ckeditor/colorbutton` (4.10.1)
- `library-ckeditor/panelbutton` (4.10.1)

Drops both the `require` entries and the matching custom package `repositories` definitions (dist URLs on `download.ckeditor.com`).

## Why

CKEditor 4 was removed from Drupal core in Drupal 10/11; this distribution ships CKEditor 5. These plugins are CKEditor-4-only (`download.ckeditor.com` addon host, versions 4.10.x / 4.12.x) and are consumed solely by legacy CKEditor 4 wrapper modules that are disabled. Font family / size controls are now provided by the CKEditor 5 font plugin pack (`ckeditor5_plugin_pack_font`). The packages have no effect in the current distro — they only pull dead CKEditor 4 assets on every install from an external, EOL download host.

## Scope

All three CKEditor 4 libs required by this profile. The remaining orphan CKEditor 4 repo declarations (`colordialog`, `glyphicons`) live only in the project template and are handled by the companion PR.

## Coordination

Companion: YCloudYUSA/yusaopeny-project#71 (template `repositories`). **Merge this PR first, then #71.**

## Test plan

- `composer validate` passes
- fresh `composer install` of the distro succeeds without the CKEditor 4 libs
- CKEditor 5 editors unaffected
