### PR TITLE
chore: post-release bump to 11.3.1.7-dev + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## System Requirements
 
-- **Drupal**: 11.1.x
+- **Drupal**: 11.3.x
 - **PHP**: 8.3 or higher
 - **Composer**: 2.0 or higher
 - **Database**: MySQL 8.0+ or MariaDB 10.6+

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -1,7 +1,7 @@
 name: YMCA Website Services
 type: profile
 description: 'YMCA Website Services Drupal 11+ distribution.'
-version: '11.3.1.6'
+version: '11.3.1.7-dev'
 core_version_requirement: ^11.1 || ^11.3
 distribution:
   name: YMCA Website Services


### PR DESCRIPTION
Post-release housekeeping after tagging `11.3.1.6`.

- `openy.info.yml` version: `11.3.1.6` → `11.3.1.7-dev` (next dev suffix per release process)
- README System Requirements: **Drupal 11.1.x → 11.3.x** (distribution now requires `>=11.3 <11.4` after #376)